### PR TITLE
Add `dvr-scan-headless` distribution, make OpenCV and pillow mandatory dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,12 +75,23 @@ jobs:
           python -m build
           echo "dvr_scan_version=`python -c \"import dvr_scan; print(dvr_scan.__version__.replace('-', '.'))\"`" >> "$GITHUB_ENV"
 
+      - name: Build Package (Headless)
+        shell: bash
+        run: |
+          python dist/tweak_setup_cfg_for_headless.py
+          python -m build
+          git reset --hard HEAD
+
       - name: Smoke Test (Source)
         run: |
           uv pip install dist/dvr_scan-${{ env.dvr_scan_version }}.tar.gz
           python -m dvr_scan --version
           python -m dvr_scan -i tests/resources/simple_movement.mp4 -so -df 4 -et 100
           uv pip uninstall dvr-scan
+          uv pip install dist/dvr_scan_headless-${{ env.dvr_scan_version }}.tar.gz
+          python -m dvr_scan --version
+          python -m dvr_scan -i tests/resources/simple_movement.mp4 -so -df 4 -et 100
+          uv pip uninstall dvr-scan-headless
 
       - name: Smoke Test (Wheel)
         run: |
@@ -88,6 +99,10 @@ jobs:
           python -m dvr_scan --version
           python -m dvr_scan -i tests/resources/simple_movement.mp4 -so -df 4 -et 100
           uv pip uninstall dvr-scan
+          uv pip install dist/dvr_scan_headless-${{ env.dvr_scan_version }}-py3-none-any.whl
+          python -m dvr_scan --version
+          python -m dvr_scan -i tests/resources/simple_movement.mp4 -so -df 4 -et 100
+          uv pip uninstall dvr-scan-headless
 
       - name: Upload Package
         if: ${{ matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y python3 python3-pip libgl1-mesa-glx libglib2.0-0
 
-RUN pip3 install dvr-scan[opencv]
+RUN pip3 install dvr-scan
 
 WORKDIR /video/
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DVR-Scan is a command-line application that **automatically detects motion event
 
 ## Quick Install
 
-    pip install dvr-scan[opencv] --upgrade
+    pip install dvr-scan --upgrade
 
 Windows builds (installer + portable) are also available on [the Downloads page](https://www.dvr-scan.com/download/).
 

--- a/dist/tweak_setup_cfg_for_headless.py
+++ b/dist/tweak_setup_cfg_for_headless.py
@@ -1,0 +1,59 @@
+#
+#      DVR-Scan: Video Motion Event Detection & Extraction Tool
+#   --------------------------------------------------------------
+#       [  Site: https://www.dvr-scan.com/                 ]
+#       [  Repo: https://github.com/Breakthrough/DVR-Scan  ]
+#
+# Copyright (C) 2016 Brandon Castellano <http://www.bcastell.com>.
+#
+
+# This script generates a headless (no GUI) version of the package
+# by modifying the setup.cfg file. When the project is next built,
+# the headless variant will be used.
+#
+# *WARNING*: This modifies the existing setup.cfg file in place.
+# The changes must be reverted to restore the full package.
+#
+
+import configparser
+import os
+
+COPYRIGHT_TEXT = """#
+#      DVR-Scan: Video Motion Event Detection & Extraction Tool
+#   --------------------------------------------------------------
+#       [  Site: https://www.dvr-scan.com/                 ]
+#       [  Repo: https://github.com/Breakthrough/DVR-Scan  ]
+#
+# Copyright (C) 2016 Brandon Castellano <http://www.bcastell.com>.
+#
+
+"""
+
+# Correctly locate setup.cfg relative to the script's location
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.abspath(os.path.join(script_dir, ".."))
+setup_cfg_path = os.path.join(project_root, "setup.cfg")
+
+# Read setup.cfg
+config = configparser.ConfigParser()
+# Preserve case of keys
+config.optionxform = str
+config.read(setup_cfg_path)
+
+assert config.has_option("metadata", "name")
+name = config.get("metadata", "name")
+config.set("metadata", "name", f"{name}-Headless")
+
+# Remove dvr-scan-app from console_scripts
+assert config.has_section("options.entry_points")
+assert config.has_option("options.entry_points", "console_scripts")
+scripts = config.get("options.entry_points", "console_scripts").splitlines()
+scripts = [s.strip() for s in scripts if s.strip() and "dvr-scan-app" not in s]
+config.set("options.entry_points", "console_scripts", "\n" + "\n".join(scripts))
+
+# Write back to setup.cfg
+with open(setup_cfg_path, "w") as configfile:
+    configfile.write(COPYRIGHT_TEXT)
+    config.write(configfile)
+
+print("Successfully generated headless setup.cfg.")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -346,6 +346,8 @@ This version of DVR-Scan includes a new, faster background subtraction algorithm
 
 ### In Development
 
+ * [general] The Python distribution now requires `opencv-python`
+    *  There is a separate `dvr-scan-headless` package available for servers which requires `opencv-python-headless` and only includes CLI functionality
  * [feature] various UI enhancements:
      * input videos can now be sorted
      * add button to open log folder

--- a/docs/download.md
+++ b/docs/download.md
@@ -15,11 +15,11 @@ hide:
 
     <h3>pipx (recommended):</h3>
 
-        pipx install dvr-scan[opencv]
+        pipx install dvr-scan
 
     <h3>pip:</h3>
 
-        python3 -m pip install dvr-scan[opencv]
+        python3 -m pip install dvr-scan
 
 DVR-Scan requires Python 3.9 or higher to run, and works on Windows, Linux, and OSX. [`pipx` is recommended](https://pipx.pypa.io/stable/installation/) for installing DVR-Scan, however installing via `pip` or from source is also supported.
 
@@ -40,7 +40,7 @@ The installer is recommended for most users.  Windows builds include all require
 
 ## Servers
 
-For headless systems that do not require the UI,  you can install `dvr-scan[opencv-headless]`.  This will make sure that [the headless version of OpenCV](https://pypi.org/project/opencv-python-headless/) is installed, which avoids any dependencies on X11 libraries or any other GUI components.  This allows DVR-Scan to run with less dependencies, and can result in smaller Docker images.
+For headless systems that do not require the UI,  you can install `dvr-scan-headless`.  This will make sure that [the headless version of OpenCV](https://pypi.org/project/opencv-python-headless/) is installed, which avoids any dependencies on X11 libraries or any other GUI components.  This allows DVR-Scan to run with less dependencies, and can result in smaller Docker images.
 
 -------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,14 @@
+#
+#      DVR-Scan: Video Motion Event Detection & Extraction Tool
+#   --------------------------------------------------------------
+#       [  Site: https://www.dvr-scan.com/                 ]
+#       [  Repo: https://github.com/Breakthrough/DVR-Scan  ]
+#
+# Copyright (C) 2016 Brandon Castellano <http://www.bcastell.com>.
+#
 
 [metadata]
-name = dvr-scan
+name = DVR-Scan
 version = attr: dvr_scan.__version__
 license = BSD 2-Clause License
 author = Brandon Castellano
@@ -42,6 +50,9 @@ install_requires =
     scenedetect
     screeninfo
     tqdm
+    opencv-python
+    opencv-contrib-python
+    pillow
 packages =
 # Main application
     dvr_scan
@@ -54,14 +65,6 @@ packages =
     dvr_scan.docs.assets.stylesheets
 python_requires = >=3.9
 include_package_data = True
-
-# TODO: Split the headless version into it's own package so we can directly depend on
-# everything below.
-[options.extras_require]
-opencv =
-    opencv-python
-    pillow
-opencv-headless = opencv-python-headless
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Add a new `dvr-scan-headless` package that provides only the CLI and depends on `opencv-python-headless`. Change existing package to depend on `opencv-python` and `pillow` rather than requiring it to be specified as an option.