### PR TITLE
[app] Fix overlays stuck on #218

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -346,6 +346,7 @@ This version of DVR-Scan includes a new, faster background subtraction algorithm
 
 ### In Development
 
+ * [bugfix] Fix bounding box overlay stuck on when using the OpenCV output mode [#213](https://github.com/Breakthrough/DVR-Scan/issues/209)
  * [feature] various UI enhancements:
      * input videos can now be sorted
      * add button to open log folder

--- a/dvr_scan/cli.py
+++ b/dvr_scan/cli.py
@@ -370,7 +370,7 @@ def get_cli_parser(user_config: ConfigRegistry):
         metavar="smooth_time",
         type=timecode_type_check("smooth_time"),
         nargs="?",
-        const=False,
+        const=True,
         help=(
             "If set, draws a bounding box around the area where motion was detected. The amount"
             " of temporal smoothing can be specified in either frames (12345) or seconds (number"


### PR DESCRIPTION
The logic to check bounding box is a bit complicated in the shared module as it's different for the CLI vs. config file. This changes it to make the differences more clear, and also updates the flag value from False to True. This simplifies checks, and also allows us to fallback so that if the value is not a boolean, we can assume the user specified smoothing time via the `-bb` CLI flag (in which case the config option is overriden). When the `-bb` flag is set alone, or from the UI, the bounding-box-smooth-time setting is used as expected.