### PR TITLE
[scanner] Use pathlib.Path for paths everywhere

### DIFF
--- a/dvr_scan/controller.py
+++ b/dvr_scan/controller.py
@@ -13,10 +13,10 @@
 This module manages the DVR-Scan program control flow, starting with `run_dvr_scan()`.
 """
 
-import glob
 import logging
 import time
 import typing as ty
+from pathlib import Path
 
 from scenedetect import FrameTimecode
 
@@ -39,7 +39,8 @@ def _preprocess_args(args):
     input_files = []
     for files in args.input:
         for file in files:
-            expanded = glob.glob(file)
+            path = Path(file)
+            expanded = list(Path.cwd().glob(file)) if not path.is_absolute() else [path]
             if not expanded:
                 logger.error("Error: Input file does not exist:\n  %s", file)
                 return False, None
@@ -94,7 +95,7 @@ def parse_settings() -> ty.Optional[ScanSettings]:
             init_log += config.consume_init_log()
         if hasattr(args, "config"):
             config_setting = ConfigRegistry()
-            config_setting.load(args.config)
+            config_setting.load(Path(args.config))
             init_logging(args, config_setting)
             config = config_setting
         init_log += config.consume_init_log()

--- a/dvr_scan/platform.py
+++ b/dvr_scan/platform.py
@@ -169,16 +169,6 @@ def init_logger(
     return logging.getLogger("dvr_scan")
 
 
-def get_filename(path: ty.AnyStr, include_extension: bool) -> ty.AnyStr:
-    """Get filename of the given path, optionally excluding extension."""
-    filename = os.path.basename(path)
-    if not include_extension:
-        dot_position = filename.rfind(".")
-        if dot_position > 0:
-            filename = filename[:dot_position]
-    return filename
-
-
 def get_system_version_info(separator_width: int = 40) -> str:
     """Get the system's operating system, Python, packages, and external tool versions.
     Useful for debugging or filing bug reports.

--- a/tests/test_video_joiner.py
+++ b/tests/test_video_joiner.py
@@ -18,7 +18,7 @@ CORRUPT_VIDEO_TOTAL_FRAMES = 596
 
 def test_decode_single(traffic_camera_video):
     """Test VideoJoiner with a single video as input."""
-    video = VideoJoiner(traffic_camera_video)
+    video = VideoJoiner([traffic_camera_video])
     assert video.total_frames == TRAFFIC_CAMERA_VIDEO_TOTAL_FRAMES
     while video.read(False) is True:
         pass


### PR DESCRIPTION
In #220 it seems path separators are inconsistent due to mixing path types. We now ensure pathlib.Path is used everywhere to avoid issues like that.